### PR TITLE
Message Embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "homepage": "https://jade3375.github.io/revbot.js/",
   "author": "Jade3375",
-  "license": "MIT License",
+  "license": "MIT",
   "packageManager": "yarn@4.9.1",
   "devDependencies": {
     "@mxssfd/typedoc-theme": "^1.1.7",


### PR DESCRIPTION
### MessageManager Enhancements:
* Added `SendableEmbed` to the imports in `src/managers/messageManager.ts` to enable handling of embeds.
* Introduced a new `embeds` array in the `send` method of `MessageManager` to collect and process embed objects.
* Enhanced the `send` method to include embeds in the request body when sending a message. This ensures that messages can now include embed data alongside other content.