### PR TITLE
Enhancement/rest error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revbot.js",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A Revolt bot client used to interact with the revolt api for Node.js, written in TypeScript.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/client/baseClient.ts
+++ b/src/client/baseClient.ts
@@ -6,7 +6,7 @@ import type {
   User,
 } from "../struct/index";
 import { EventEmitter } from "node:events";
-import { Events } from "../utils/constants";
+import { DEFAULT_CLIENT_OPTIONS, Events } from "../utils/constants";
 import { RestClient } from "../rest/restClient";
 import { Message } from "../struct/index";
 import { client } from "./client";
@@ -172,6 +172,7 @@ export abstract class BaseClient extends EventEmitter {
   constructor(options: clientOptions = {}) {
     super();
     this.options = {
+      ...DEFAULT_CLIENT_OPTIONS,
       ...options,
     };
     this.bot = this.options.isBot ?? true;

--- a/src/rest/CDNClient.ts
+++ b/src/rest/CDNClient.ts
@@ -1,6 +1,6 @@
-import axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { BaseClient } from "../client/baseClient";
-import { cdnUrl } from "../utils";
+import { cdnUrl, DEFAULT_CLIENT_OPTIONS } from "../utils";
 import { version } from "../../package.json";
 import FormData from "form-data";
 import { RateLimitQueue } from "./restUtils/rateLimitQueue";
@@ -21,6 +21,7 @@ export class CDNClient {
     url: string,
     data: FormData,
     query?: Record<string, string | number>,
+    retry?: boolean,
   ): Promise<T> {
     try {
       if (!this.client.token) throw new Error("Token is required");
@@ -48,11 +49,49 @@ export class CDNClient {
         await this.rateLimitQueue.request<T>(config);
       return response.data;
     } catch (error) {
-      console.error("API call failed:", error);
-      throw error;
+      if (retry) throw typeof error;
+      if (error instanceof AxiosError) {
+        if (error.status && (error.status === 429 || error.status >= 500)) {
+          return this.retryRequest<T>(0, method, url, data, query);
+        }
+        if (error.status) {
+          console.error(`API call failed with status ${error.status}:`, error);
+          throw new Error(
+            `API call failed with status ${error.status}: ${error.message}`,
+          );
+        }
+      }
+      throw new Error(
+        `API call failed: ${error instanceof Error ? error.message : error}`,
+      );
     }
   }
 
+  private async retryRequest<T>(
+    attempt: number = 0,
+    method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE",
+    url: string,
+    body?: any,
+    query?: Record<string, string | number>,
+  ): Promise<T> {
+    if (attempt >= (this.client.options.rest?.retries ?? 3)) {
+      throw new Error("Max retries reached");
+    }
+
+    try {
+      return await this.request<T>(method, url, body, query, true);
+    } catch (error) {
+      console.warn(`Attempt ${attempt + 1} failed:`, error);
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          this.client.options.rest?.timeout ??
+            DEFAULT_CLIENT_OPTIONS.rest?.timeout,
+        ),
+      );
+      return this.retryRequest<T>(attempt + 1, method, url, body, query);
+    }
+  }
   /**
    * POST request.
    * @param url The URL for the request.


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to improve error handling, retry logic, and default configuration management across the `BaseClient`, `CDNClient`, and `RestClient` classes. It also updates the package version. Below are the most important changes grouped by theme:

### Error Handling and Retry Logic:

* Enhanced error handling in `CDNClient` and `RestClient` by adding support for retry logic when API calls fail due to rate limits (status 429) or server errors (status >= 500). This includes the introduction of a `retryRequest` method to handle retries with configurable limits and timeouts. (`src/rest/CDNClient.ts`, [[1]](diffhunk://#diff-67073e09c7dd40e8d5686e7668e61a84eef173cac0deb643b646c6b55051481fL51-R94); `src/rest/restClient.ts`, [[2]](diffhunk://#diff-fe79444fe9ad684d35a39756fa1ac382209d9fd1ae29033ddc1f2534e7c67c17L48-R89)

* Improved error messages for failed API calls, providing more detailed information about the error status and message. (`src/rest/CDNClient.ts`, [[1]](diffhunk://#diff-67073e09c7dd40e8d5686e7668e61a84eef173cac0deb643b646c6b55051481fL51-R94); `src/rest/restClient.ts`, [[2]](diffhunk://#diff-fe79444fe9ad684d35a39756fa1ac382209d9fd1ae29033ddc1f2534e7c67c17L48-R89)

### Default Configuration Management:

* Integrated `DEFAULT_CLIENT_OPTIONS` into the `BaseClient` constructor to ensure default options are applied consistently. (`src/client/baseClient.ts`, [[1]](diffhunk://#diff-c4dd095167ff8e66280e804bf9a8cab8bfdbc20fe7629dc9406b47ce9bd11dcaL9-R9) [[2]](diffhunk://#diff-c4dd095167ff8e66280e804bf9a8cab8bfdbc20fe7629dc9406b47ce9bd11dcaR175)

* Updated imports in `CDNClient` and `RestClient` to include `DEFAULT_CLIENT_OPTIONS` for consistent access to default settings. (`src/rest/CDNClient.ts`, [[1]](diffhunk://#diff-67073e09c7dd40e8d5686e7668e61a84eef173cac0deb643b646c6b55051481fL1-R3); `src/rest/restClient.ts`, [[2]](diffhunk://#diff-fe79444fe9ad684d35a39756fa1ac382209d9fd1ae29033ddc1f2534e7c67c17L1-R3)

### Miscellaneous:

* Added a `retry` parameter to the `request` method in both `CDNClient` and `RestClient` to control retry behavior. (`src/rest/CDNClient.ts`, [[1]](diffhunk://#diff-67073e09c7dd40e8d5686e7668e61a84eef173cac0deb643b646c6b55051481fR24); `src/rest/restClient.ts`, [[2]](diffhunk://#diff-fe79444fe9ad684d35a39756fa1ac382209d9fd1ae29033ddc1f2534e7c67c17R24)

* Updated the package version in `package.json` from `0.0.9` to `0.0.10`. (`package.json`, [package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3))