### PR TITLE
feat: add masquerade support in message options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "revbot.js",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A Revolt bot client used to interact with the revolt api for Node.js, written in TypeScript.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/managers/messageManager.ts
+++ b/src/managers/messageManager.ts
@@ -1,5 +1,6 @@
 import type {
   Message as APIMessage,
+  Masquerade,
   MessageSort,
   SendableEmbed,
 } from "revolt-api";
@@ -24,6 +25,7 @@ export interface MessageOptions {
   replies?: MessageReply[];
   attachments?: Readable[] | string[] | File[];
   embeds?: MessageEmbed[];
+  masquerade?: Masquerade;
 }
 
 export interface MessageEditOptions {

--- a/src/struct/message.ts
+++ b/src/struct/message.ts
@@ -1,4 +1,9 @@
-import type { File, Message as APIMessage, SystemMessage } from "revolt-api";
+import type {
+  File,
+  Message as APIMessage,
+  SystemMessage,
+  Masquerade,
+} from "revolt-api";
 import type { client } from "../client/client";
 import type { MessageEditOptions, MessageOptions } from "../managers/index";
 import {
@@ -46,6 +51,9 @@ export class MessageStruct extends Base {
 
   /** the reactions and count on a message */
   reactions: Map<string, string[]> = new Map();
+
+  /** Masquerade information for the message, Name and / or avatar override information */
+  masquerade?: Masquerade;
 
   /**
    * Creates a new Message instance.


### PR DESCRIPTION
This pull request introduces support for masquerade functionality in messages, allowing users to override the name and/or avatar when sending messages. The changes include updating type imports, extending message options, and adding a new property to the message structure.

Masquerade support:

* Added the `Masquerade` type import from `revolt-api` to both `messageManager.ts` and `message.ts` to support masquerade data. [[1]](diffhunk://#diff-0740ec5039cbfe576c5c336cbc25824736567966f5de9430cabd7c267877b044R3) [[2]](diffhunk://#diff-caad8afc07a6576e6009df732ffaf1366488f25a890f88c26e685d89c30f5694L1-R6)
* Extended the `MessageOptions` interface in `messageManager.ts` to include an optional `masquerade` property, enabling users to specify masquerade information when sending messages.
* Added an optional `masquerade` property to the `MessageStruct` class in `message.ts` to store and expose masquerade information on message instances.

Other:

* Bumped the package version from `0.1.7` to `0.1.8` in `package.json` to reflect the new feature addition.