### PR TITLE
Fixed the default avatar url in displayAvatarURL

### DIFF
--- a/src/struct/user.ts
+++ b/src/struct/user.ts
@@ -157,7 +157,7 @@ export class User extends Base {
   }
 
   async displayAvatarURL(): Promise<string> {
-    const defaultAvatar = `${this.client.options.rest?.instanceCDNURL ? this.client.options.rest?.instanceCDNURL : apiUrl}/users/${this.id}/default_avatar`;
+    const defaultAvatar = `${this.client.options.rest?.instanceURL ? this.client.options.rest?.instanceURL : apiUrl}/users/${this.id}/default_avatar`;
     return this.avatarURL() ?? defaultAvatar;
   }
 


### PR DESCRIPTION
The default avatar url (when they have no pfp set) was pointing to the CDN url when it should point to the api url `https://api.revolt.chat/users/{target}/default_avatar`